### PR TITLE
Update README with reCAPTCHA site key note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ npx serve public
 
 This hosts `index.html` which loads the form scripts. Update `scripts/upload.js` with your Supabase credentials if necessary.
 
+Replace the `YOUR_SITE_KEY` placeholder in `public/index.html` with a real site key from Google reCAPTCHA. Register your domain in the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) to generate a key.
+
 ### Running the API
 
 `api/submit.js` exports a Node handler. You can run it locally with a lightweight server such as `micro`:


### PR DESCRIPTION
## Summary
- document that public/index.html requires a Google reCAPTCHA site key
- explain how to obtain the site key from Google

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863706859908327a284f56fcc561338