### PR TITLE
Inject Supabase vars via globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Set the following variables before starting the API:
 - SUPABASE_URL – URL of your Supabase instance.
 - SUPABASE_ANON_KEY – anon/public key for Supabase.
 
+Expose these same values to the frontend by defining
+`window.SUPABASE_URL` and `window.SUPABASE_ANON_KEY` in your page:
+
+```html
+<script>
+  window.SUPABASE_URL = 'https://your-project.supabase.co';
+  window.SUPABASE_ANON_KEY = 'public-anon-key';
+</script>
+```
+
 ### Running the frontend
 
 Serve the `public/` directory with any static file server, for example:
@@ -21,7 +31,7 @@ Serve the `public/` directory with any static file server, for example:
 npx serve public
 ```
 
-This hosts `index.html` which loads the form scripts. Update `scripts/upload.js` with your Supabase credentials if necessary.
+This hosts `index.html` which loads the form scripts.
 
 ### Running the API
 

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -1,7 +1,11 @@
-const supabaseClient = window.supabase.createClient(
-  'https://rdnykfqczccsavwouhhk.supabase.co',
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJkbnlrZnFjemNjc2F2d291aGhrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTEyMDg1MjgsImV4cCI6MjA2Njc4NDUyOH0.bmC3ZXqfmYhPmeinLnLDINR5sLCHkO_EfkCx6u_AyJw'
-);
+const supabaseUrl = window.SUPABASE_URL;
+const supabaseAnonKey = window.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be defined.');
+}
+
+const supabaseClient = window.supabase.createClient(supabaseUrl, supabaseAnonKey);
 
 const dropzone = document.getElementById('dropzone');
 const fileInput = document.getElementById('photos');


### PR DESCRIPTION
## Summary
- read Supabase credentials from global variables
- document how to expose these globals during setup

## Testing
- `node -v`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863703bcda883278c065285e30b63c0