### PR TITLE
Add ES module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ This hosts `index.html` which loads the form scripts. Update `scripts/upload.js`
 
 ### Running the API
 
-`api/submit.js` exports a Node handler. You can run it locally with a lightweight server such as `micro`:
+The API handler in `api/submit.js` uses ES module syntax. A minimal
+`package.json` in the repository root sets `"type": "module"` so that Node will
+load the file correctly.
+
+You can run the handler locally with a lightweight server such as `micro`:
 
 ```
 npx micro api/submit.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- add `package.json` defining ES module usage
- note ES module setup in README

## Testing
- `node -e "import('./api/submit.js').then(m=>console.log(typeof m.default))"`
- `npx micro --version` *(fails: requires package download and environment lacks network access)*

------
https://chatgpt.com/codex/tasks/task_e_68636dc317748327a0ed6a12d1ccd8f9