### PR TITLE
Use micro JSON helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Replace the `YOUR_SITE_KEY` placeholder in `public/index.html` with a real site 
 
 The API handler in `api/submit.js` uses ES module syntax. A minimal
 `package.json` in the repository root sets `"type": "module"` so that Node will
-load the file correctly.
+load the file correctly. It also uses `micro`'s `json` helper to read the request
+body.
 
 You can run the handler locally with a lightweight server such as `micro`:
 

--- a/api/submit.js
+++ b/api/submit.js
@@ -1,3 +1,5 @@
+import { json as parseJson } from 'micro';
+
 export default async function handler(req, res) {
   if (req.method === 'OPTIONS') {
     res.setHeader('Access-Control-Allow-Origin', 'https://sugar-free.family');
@@ -13,7 +15,7 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { fields, captchaToken } = req.body;
+  const { fields, captchaToken } = await parseJson(req);
 
   // 🔐 reCAPTCHA verification
   const RECAPTCHA_SECRET = process.env.RECAPTCHA_SECRET;


### PR DESCRIPTION
## Summary
- parse request bodies with micro's `json` helper
- document usage of micro in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68645db28e8c8327838fee6434d2307f