### PR TITLE
Insert reCAPTCHA site key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx serve public
 
 This hosts `index.html` which loads the form scripts.
 
-Replace the `YOUR_SITE_KEY` placeholder in `public/index.html` with a real site key from Google reCAPTCHA. Register your domain in the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) to generate a key.
+The form includes a reCAPTCHA widget using the site key `6LeJTHIrAAAAANJXinmmjlQ__RdHmph6_pCo4H4u`. If you have your own site key, update the `data-sitekey` attribute in `public/index.html` accordingly. Register your domain in the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) to generate a key.
 
 ### Running the API
 

--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
         <input type="file" id="photos" accept="image/*" multiple hidden>
       </div>
       <div id="image-preview" style="display: flex; flex-wrap: wrap; gap: 1rem;"></div>
-      <div class="g-recaptcha" data-sitekey="YOUR_SITE_KEY"></div>
+      <div class="g-recaptcha" data-sitekey="6LeJTHIrAAAAANJXinmmjlQ__RdHmph6_pCo4H4u"></div>
       <br>
       <button type="submit">Submit</button>
     </form>


### PR DESCRIPTION
## Summary
- use the provided reCAPTCHA site key in `public/index.html`
- update README with info about the configured site key

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68645b450b80832796957c20d36cffaf