### PR TITLE
Add dimension validation for uploaded images

### DIFF
--- a/__tests__/upload.test.js
+++ b/__tests__/upload.test.js
@@ -1,18 +1,18 @@
 import { isValidFile } from '../public/scripts/upload.js';
 
 describe('isValidFile', () => {
-  test('accepts valid jpeg file under limit', () => {
+  test('accepts valid jpeg file under limit', async () => {
     const file = { type: 'image/jpeg', size: 2 * 1024 * 1024 };
-    expect(isValidFile(file)).toBe(true);
+    await expect(isValidFile(file)).resolves.toBe(true);
   });
 
-  test('rejects file exceeding size limit', () => {
+  test('rejects file exceeding size limit', async () => {
     const file = { type: 'image/png', size: 10 * 1024 * 1024 };
-    expect(isValidFile(file)).toBe(false);
+    await expect(isValidFile(file)).resolves.toBe(false);
   });
 
-  test('rejects invalid mime type', () => {
+  test('rejects invalid mime type', async () => {
     const file = { type: 'audio/mpeg', size: 512 };
-    expect(isValidFile(file)).toBe(false);
+    await expect(isValidFile(file)).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- validate image dimensions in `isValidFile`
- make `handleFiles` async to await validation
- update tests for new async behavior

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864674b3374832793ca6e6f71616811